### PR TITLE
修改 CMSIS 默认定时器为硬件定时器

### DIFF
--- a/src/cmsis_rtthread.c
+++ b/src/cmsis_rtthread.c
@@ -942,7 +942,7 @@ osTimerId_t osTimerNew(osTimerFunc_t func, osTimerType_t type, void *argument, c
     timer_cb_t *timer_cb;
     char name[RT_NAME_MAX];
     static rt_uint16_t timer_number = 0U;
-    rt_uint8_t flag = RT_TIMER_FLAG_SOFT_TIMER;
+    rt_uint8_t flag = RT_TIMER_FLAG_HARD_TIMER;
 
     /* Check parameters */
     if ((RT_NULL == func) || ((type != osTimerOnce) && (type != osTimerPeriodic)))


### PR DESCRIPTION
在 CMSIS 环境中定时器回调函数是在线程的上下文环境实现的，所以修改定时器为硬件定时器， 使定时器回调函数在中断上下文中实现。